### PR TITLE
Add missing event argument to ArrowDown handler

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -103,7 +103,7 @@ let Autocomplete = React.createClass({
   },
 
   keyDownHandlers: {
-    ArrowDown () {
+    ArrowDown (event) {
       event.preventDefault()
       var { highlightedIndex } = this.state
       var index = (


### PR DESCRIPTION
Pull in @mwanji's arrow down event fix.
